### PR TITLE
Warning on possibly bad dynamic string decoder if all results were null

### DIFF
--- a/de4dot.code/ObfuscatedFile.cs
+++ b/de4dot.code/ObfuscatedFile.cs
@@ -370,6 +370,8 @@ namespace de4dot.code {
 
 			deob.DeobfuscateBegin();
 			DeobfuscateMethods();
+			if (options.StringDecrypterType == DecrypterType.Delegate || options.StringDecrypterType == DecrypterType.Emulate)
+				dynamicStringInliner.LogUnusedDecrypters();
 			deob.DeobfuscateEnd();
 		}
 


### PR DESCRIPTION
If the user specifies a delegate or emulate dynamic string decrypter warn them if all it returns is null.