### PR TITLE
Add support of .Net Core 7.0.

### DIFF
--- a/De4DotCommon.props
+++ b/De4DotCommon.props
@@ -5,7 +5,7 @@
     <De4DotNetFramework Condition=" '$(SolutionName)' == 'de4dot.netframework' ">true</De4DotNetFramework>
     <!-- Two different sln files are used because some of the projects are only available when targetting .NET Framework -->
     <TargetFrameworks Condition=" '$(De4DotNetFramework)' == 'true' ">net35;net48</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(De4DotNetFramework)' != 'true' ">netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(De4DotNetFramework)' != 'true' ">net7.0</TargetFrameworks>
     <Features>strict</Features>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ de4dot is an open source (GPLv3) .NET deobfuscator and unpacker written in C#. I
 
 It uses [dnlib](https://github.com/0xd4d/dnlib/) to read and write assemblies so make sure you get it or it won't compile.
 
+***WARNING***: `de4dot` uses `BinaryFormatter` in some backends (`BabelNET` and `CodeVeil`). Code obfuscated with these deobfuscators (or the one, that tricks `de4dot` to detect so) will cause execution of arbitrary code during deobfuscation. For example it may be possible to write code tracking attempts of applying `de4dot`. A more proper solution is needed for deobfuscating such binaries, such as a completely own parser doing the deserialization safely. Read https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide for more info.
+
 Binaries
 ========
 

--- a/de4dot.code/deobfuscators/Babel_NET/ConstantsDecrypter.cs
+++ b/de4dot.code/deobfuscators/Babel_NET/ConstantsDecrypter.cs
@@ -238,7 +238,10 @@ namespace de4dot.code.deobfuscators.Babel_NET {
 
 		byte[] DecryptArray(byte[] encryptedData, int elemSize) {
 			var decrypted = resourceDecrypter.Decrypt(encryptedData);
+			#pragma warning disable SYSLIB0011
+			#warning "Insecure! Rewrite with custom parser https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide"
 			var ary = (Array)new BinaryFormatter().Deserialize(new MemoryStream(decrypted));
+			#pragma warning restore SYSLIB0011
 			if (ary is byte[])
 				return (byte[])ary;
 			var newAry = new byte[ary.Length * elemSize];

--- a/de4dot.code/deobfuscators/CodeVeil/ResourceConverter.cs
+++ b/de4dot.code/deobfuscators/CodeVeil/ResourceConverter.cs
@@ -164,7 +164,10 @@ namespace de4dot.code.deobfuscators.CodeVeil {
 		public static readonly string ReflectionTypeName = "System.Char[],mscorlib";
 		char[] data;
 		public CharArrayResourceData(UserResourceType type, char[] data) : base(type) => this.data = data;
+		#pragma warning disable SYSLIB0011
+		#warning "Insecure! Rewrite with custom parser https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide"
 		public override void WriteData(BinaryWriter writer, IFormatter formatter) => formatter.Serialize(writer.BaseStream, data);
+		#pragma warning restore SYSLIB0011
 		public override string ToString() => $"char[]: Length: {data.Length}";
 	}
 
@@ -172,7 +175,10 @@ namespace de4dot.code.deobfuscators.CodeVeil {
 		public static readonly string ReflectionTypeName = "System.Drawing.Icon,System.Drawing";
 		Icon icon;
 		public IconResourceData(UserResourceType type, byte[] data) : base(type) => icon = new Icon(new MemoryStream(data));
+		#pragma warning disable SYSLIB0011
+		#warning "Insecure! Rewrite with custom parser https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide"
 		public override void WriteData(BinaryWriter writer, IFormatter formatter) => formatter.Serialize(writer.BaseStream, icon);
+		#pragma warning restore SYSLIB0011
 		public override string ToString() => $"Icon: {icon}";
 	}
 
@@ -180,7 +186,10 @@ namespace de4dot.code.deobfuscators.CodeVeil {
 		public static readonly string ReflectionTypeName = "System.Drawing.Bitmap,System.Drawing";
 		Bitmap bitmap;
 		public ImageResourceData(UserResourceType type, byte[] data) : base(type) => bitmap = new Bitmap(Image.FromStream(new MemoryStream(data)));
+		#pragma warning disable SYSLIB0011
+		#warning "Insecure! Rewrite with custom parser https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide"
 		public override void WriteData(BinaryWriter writer, IFormatter formatter) => formatter.Serialize(writer.BaseStream, bitmap);
+		#pragma warning restore SYSLIB0011
 		public override string ToString() => "Bitmap";
 	}
 }

--- a/deobfuscator.Template/deobfuscator.Template.csproj
+++ b/deobfuscator.Template/deobfuscator.Template.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net48;net7.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\de4dot.snk</AssemblyOriginatorKeyFile>
     <Features>strict</Features>


### PR DESCRIPTION
Disable compile errors around unsafe deserialization routines. Add a warning about the insecure deserialization into the ReadMe.

Support of .netcore7 is needed to allow it run on Linux when it is installed without installation of legacy versions (which take a lot of space).